### PR TITLE
Harry/fix incorrect error deserialization 

### DIFF
--- a/snowflake-api/src/lib.rs
+++ b/snowflake-api/src/lib.rs
@@ -486,8 +486,8 @@ impl SnowflakeApi {
         }?;
 
         while resp.is_async() {
-            let url = resp.data.get_result_url.as_ref().unwrap();
-            resp = match self.poll::<ExecResponse>(&url).await? {
+            let async_data = resp.data.as_async().expect("Expected async data");
+            resp = match self.poll::<ExecResponse>(&async_data.get_result_url).await? {
                 ExecResponse::Query(qr) => qr,
                 ExecResponse::PutGet(_) => return Err(SnowflakeApiError::UnexpectedResponse),
                 ExecResponse::Error(e) => {
@@ -502,29 +502,29 @@ impl SnowflakeApi {
         // if response was empty, base64 data is empty string
         // todo: still return empty arrow batch with proper schema? (schema always included)
         // the unwrap is safe, because we checked for async status
-        if resp.data.returned.unwrap() == 0 {
+        let sync_data = resp.data.as_sync().expect("Expected sync data");
+        if sync_data.returned == 0 {
             log::debug!("Got response with 0 rows");
             Ok(RawQueryResult::Empty)
-        } else if let Some(value) = resp.data.rowset {
+        } else if let Some(value) = sync_data.rowset {
             log::debug!("Got JSON response");
             // NOTE: json response could be chunked too. however, go clients should receive arrow by-default,
             // unless user sets session variable to return json. This case was added for debugging and status
             // information being passed through that fields.
             Ok(RawQueryResult::Json(JsonResult {
                 value,
-                schema: resp
-                    .data
+                schema: sync_data
                     .rowtype
                     .unwrap()
                     .into_iter()
                     .map(Into::into)
                     .collect(),
             }))
-        } else if let Some(base64) = resp.data.rowset_base64 {
+        } else if let Some(base64) = sync_data.rowset_base64 {
             // fixme: is it possible to give streaming interface?
-            let mut chunks = try_join_all(resp.data.chunks.iter().map(|chunk| {
+            let mut chunks = try_join_all(sync_data.chunks.iter().map(|chunk| {
                 self.connection
-                    .get_chunk(&chunk.url, &resp.data.chunk_headers)
+                    .get_chunk(&chunk.url, &sync_data.chunk_headers)
             }))
             .await?;
 

--- a/snowflake-api/src/responses.rs
+++ b/snowflake-api/src/responses.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
+use crate::SnowflakeApiError;
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Deserialize, Debug)]
 #[serde(untagged)]
@@ -139,19 +141,19 @@ pub enum QueryExecResponseData {
 }
 
 impl QueryExecResponseData {
-    pub fn as_sync(self) -> Option<SyncQueryExecResponseData> {
+    pub fn as_sync(self) -> Result<SyncQueryExecResponseData, SnowflakeApiError> {
         if let Self::Sync(data) = self {
-            Some(data)
+            Ok(data)
         } else {
-            None
+            Err(SnowflakeApiError::UnexpectedAsyncQueryResponse)
         }
     }
 
-    pub fn as_async(self) -> Option<AsyncQueryExecResponseData> {
+    pub fn as_async(self) -> Result<AsyncQueryExecResponseData, SnowflakeApiError> {
         if let Self::Async(data) = self {
-            Some(data)
+            Ok(data)
         } else {
-            None
+            Err(SnowflakeApiError::UnexpectedAsyncQueryResponse)
         }
     }
 }


### PR DESCRIPTION
Error response below gets incorrectly deserialized as `QueryExecResponseData` due to all its fields are set to optional. This change separate async query response from sync to fix the issue
```
{
  "data" : {
  "internalError" : false,
  "errorCode" : "001998",
  "age" : 0,
  "sqlState" : "42710",
  "queryId" : "01b3ec0d-0002-5b88-0042-9807002eb66a",
  "line" : -1,
  "pos" : -1,
  "type" : "COMPILATION"
},
  "code" : "001998",
  "message" : "SQL compilation error:\nObject 'A' already exists as VIEW",
  "success" : false,
  "headers" : null
}
```

[#1957](https://github.com/sdf-labs/sdf/issues/1957)