### PR TITLE
Update dependencies

### DIFF
--- a/snowflake-api/Cargo.toml
+++ b/snowflake-api/Cargo.toml
@@ -20,7 +20,6 @@ polars = ["dep:polars-core", "dep:polars-io"]
 
 [dependencies]
 arrow = "53"
-async-trait = "0.1"
 base64 = "0.22"
 bytes = "1"
 futures = "0.3"
@@ -32,11 +31,11 @@ reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
 ] }
 reqwest-middleware = { version = "0.3", features = ["json"] }
-reqwest-retry = "0.6"
+reqwest-retry = "0.7.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snowflake-jwt = { version = "0.3", optional = true }
-thiserror = "1"
+thiserror = "2.0.12"
 url = "2"
 uuid = { version = "1", features = ["v4"] }
 


### PR DESCRIPTION
Having outdated dependencies causes duplicated dependencies in downstream crates.