### PR TITLE
chore: add more fields to responses and JsonResult

### DIFF
--- a/snowflake-api/src/responses.rs
+++ b/snowflake-api/src/responses.rs
@@ -300,6 +300,9 @@ pub struct PutGetResponseData {
     #[serde(default)]
     pub parameters: Vec<NameValueParameter>,
     pub statement_type_id: Option<i64>,
+    pub query_id: String,
+    pub send_result_time: usize,
+    pub query_context: QueryContext,
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
Don't know if you are open to PRs, but was missing the query_id, send_result_time and query_context on the responses, so added them here. Otherwise I will just work off my fork